### PR TITLE
Pass in details in options object

### DIFF
--- a/lib/fluent/plugin/out_pagerduty.rb
+++ b/lib/fluent/plugin/out_pagerduty.rb
@@ -32,11 +32,11 @@ class Fluent::PagerdutyOutput < Fluent::Output
       event_type = record['event_type'] || @event_type
       description = record['description'] || record['message'] || @description
       details = record['details'] || record
+      options = {"details" => details}
       api = Pagerduty.new(service_key)
-      incident = api.trigger description, details
+      incident = api.trigger description, options
     rescue => e
       $log.error "pagerduty: request failed. ", :error_class=>e.class, :error=>e.message
     end
   end
 end
-


### PR DESCRIPTION
This fixes issue #1. According to the PagerDuty API documentation, details is an object within the set of options.

Trigger function: https://github.com/envato/pagerduty/blob/36444b96adb4937e740e66e98124de642757f54a/lib/pagerduty.rb#L69
API documentation: https://v2.developer.pagerduty.com/docs/trigger-events