### PR TITLE
Deduplication and programmatic field building with placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 vendor/*
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ $ gem install fluent-plugin-pagerduty
 5. restart fluentd process.
 6. send test message for fluent-plugin-pagerduty
 
-#### configuration example
+### Examples
+
+#### Simple alert (JSON pass-thru)
+
+In this example, a JSON record already conforming to the PagerDuty API is processed by Fluentd and passed through to PagerDuty as-is, triggering a simple alert.
 
 ```
 <source>
@@ -42,11 +46,9 @@ $ gem install fluent-plugin-pagerduty
 
 <match notify.pagerduty>
   type pagerduty
-  service_key ******************
+  service\_key ******************
 </match>
 ```
-
-#### notify example
 
 ```
 # via forward
@@ -55,6 +57,70 @@ $ echo '{"description":"Form validation has failed","details":{"name":"success",
 # via http
 $ curl http://localhost:8888/notify.pagerduty -F 'json={"description":"Form validation has failed","details":{"name":"success","mail":"failed"}}'
 ```
+
+#### Advanced alert (transformed JSON)
+
+In this example, a JSON record is referenced to build a PagerDuty event with an incident key for managing [de-duplication](https://v2.developer.pagerduty.com/docs/events-api#incident-de-duplication-and-incident_key).
+
+```
+<source>
+  @type forward
+</source>
+
+<source>
+  @type http
+  port 8888
+</source>
+
+<match notify.pagerduty>
+  type pagerduty
+  service_key   ******************
+  description   Alarm@${Node["Location"]}:: ${Log["Message"]}
+  incident\_key  [${tag\_parts[-1]}] ${Log["File"]}:${Log["Line"]}
+</match>
+```
+
+```
+# via forward
+$ echo '{"Node":{"Location":"Somewhere","IP Address":"10.0.0.1"},"Log":{"Level": "ERROR","File":"FooBar.cpp","Line":42,"Message":"A very important logging message"}}' | fluent-cat notify.pagerduty
+
+# via http
+$ curl http://localhost:8888/notify.pagerduty -F 'json={"Node":{"Location":"Somewhere","IP Address":"10.0.0.1"},"Log":{"Level": "ERROR","File":"FooBar.cpp","Line":42,"Message":"A very important logging message"}}'
+```
+
+
+### Option Parameters
+
+- `service_key` (required)
+
+    The unique API identifier generated for each PagerDuty service belonging to a PagerDuty account. Must be present for any PagerDuty events.
+
+- `event_type` (optional)
+
+    The PagerDuty event type: `trigger`, `acknowledge`, or `resolve`. If unspecified, the default is `trigger`.
+
+- `description` (conditionally required)
+
+    The message content of a PagerDuty event. PagerDuty event types of `trigger` must contain a description. The content of the description may be built using Placeholders (see next section).
+
+- `incident_key` (optional)
+
+    The identifier used for PagerDuty's [de-duplication of events](https://v2.developer.pagerduty.com/docs/events-api#incident-de-duplication-and-incident_key). The content of the incident key may be built using Placeholders (see next section).
+
+### Placeholders
+
+These placeholders are available:
+
+* ${…}
+  * `hashName["key"]` Value of `key` in named hash
+  * `arrayName[N]` Value at index _N_ in named array
+  * `primitive` Value of named primitive
+  
+    Placeholders are built recursively and concatenated. For example, a specific value within a hash containing an array of hashes could be referenced as: `${foo["bar"][2]["baz"]}`.
+* ${tag} Input tag
+* ${tag\_parts[N]} Input tag splitted by '.' indexed with _N_ such as `${tag_parts[0]}`, `${tag_parts[-1]}`. 
+
+Placeholder functionality is derived from features of [fluent-plugin-record-reformer](https://github.com/sonots/fluent-plugin-record-reformer).
 
 ## Contributing
 
@@ -74,5 +140,5 @@ Copyright (c) 2013- Kentaro Yoshida (@yoshi_ken)
 
 ## License
 
-Apache License, Version 2.0
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In this example, a JSON record already conforming to the PagerDuty API is proces
 
 <match notify.pagerduty>
   type pagerduty
-  service\_key ******************
+  service_key ******************
 </match>
 ```
 
@@ -76,7 +76,7 @@ In this example, a JSON record is referenced to build a PagerDuty event with an 
   type pagerduty
   service_key   ******************
   description   Alarm@${Node["Location"]}:: ${Log["Message"]}
-  incident\_key  [${tag\_parts[-1]}] ${Log["File"]}:${Log["Line"]}
+  incident_key  [${tag_parts[-1]}] ${Log["File"]}:${Log["Line"]}
 </match>
 ```
 

--- a/lib/fluent/plugin/out_pagerduty.rb
+++ b/lib/fluent/plugin/out_pagerduty.rb
@@ -9,34 +9,137 @@ class Fluent::PagerdutyOutput < Fluent::Output
   config_param :service_key, :string, :default => nil
   config_param :event_type, :string, :default => 'trigger'
   config_param :description, :string, :default => nil
+  config_param :incident_key, :string, :default => nil
 
   def configure(conf)
     super
 
+    # API requires service key
     if @service_key.nil?
       $log.warn "pagerduty: service_key required."
+    end
+
+    # PagerDuty trigger event type requires description, other event types do not
+    if @event_type == 'trigger' && @description.nil?
+      $log.warn "pagerduty: description required for trigger event_type."
     end
   end
 
   def emit(tag, es, chain)
     es.each do |time,record|
-      call_pagerduty(record)
+      call_pagerduty(tag, record)
     end
 
     chain.next
   end
 
-  def call_pagerduty(record)
+  def call_pagerduty(tag, record)
     begin
+      expander = PlaceholderExpander.new({:log => log})
+      tag_parts = tag.split('.')
+      placeholder_values = {
+        'tag'       => tag,
+        'tag_parts' => tag_parts,
+        'record'    => record,
+      }
+
+      placeholders = expander.prepare_placeholders(placeholder_values)
+      
       service_key = record['service_key'] || @service_key
       event_type = record['event_type'] || @event_type
       description = record['description'] || record['message'] || @description
+      incident_key = record['incident_key'] || @incident_key
       details = record['details'] || record
       options = {"details" => details}
-      api = Pagerduty.new(service_key)
+      
+      description = expander.expand(description, placeholders)
+      
+      if !@incident_key.nil?
+        incident_key = expander.expand(incident_key, placeholders)
+        api = PagerdutyIncident.new(service_key, incident_key)
+      else
+        api = Pagerduty.new(service_key)
+      end
+
       incident = api.trigger description, options
     rescue => e
       $log.error "pagerduty: request failed. ", :error_class=>e.class, :error=>e.message
     end
   end
 end
+
+
+# Modified PlaceholderExpander borrowed from fluent-plugin-record-reformer
+# https://github.com/sonots/fluent-plugin-record-reformer
+# Original author: Naotoshi Seo
+# MIT License: https://github.com/sonots/fluent-plugin-record-reformer/blob/master/LICENSE
+# Modifications: Michael Karlesky
+# Changes:
+#  - Stripped down to limited use case
+#  - Building of placeholders is now recursive to handle any depth of hash, array, and primitive
+class PlaceholderExpander
+  attr_reader :placeholders, :log
+
+  def initialize(params)
+    @log = params[:log]
+  end
+
+  def prepare_placeholders(placeholder_values)
+    placeholders = {}
+
+    placeholder_values.each do |key, value|
+      # For any entry in `placeholder_values` that is a hash, we effectively ignore its internal name.
+      # For example, `record` is an important hash, but referencing it at the top-level is superfluous namespacing.
+      # Instead of '${record["Node"]["Location"]}',
+      #  '${Node["Location"]}' more closely maps to a user's knowledge of a data to be processed.
+      if value.kind_of?(Hash)
+        value.each do |key, value|
+          build_placeholders(placeholders, key, value)
+        end
+      else
+        build_placeholders(placeholders, key, value)        
+      end
+    end
+
+    placeholders
+  end
+
+  # Expand string (`${foo["bar"]}`) with placeholders
+  def expand(str, placeholders)
+    single_placeholder_matched = str.match(/\A(\${[^}]+}|__[A-Z_]+__)\z/)
+    if single_placeholder_matched
+      log_if_unknown_placeholder($1, placeholders)
+      return placeholders[single_placeholder_matched[1]]
+    end
+    str.gsub(/(\${[^}]+}|__[A-Z_]+__)/) {
+      log_if_unknown_placeholder($1, placeholders)
+      placeholders[$1]
+    }
+  end
+
+  private
+
+  # Recurses to build any depth of hash, arrays, and primitives
+  def build_placeholders(placeholders, key, value)
+    if value.kind_of?(Array) # tag_parts, etc
+      size = value.size
+      value.each_with_index do |v, idx|
+        build_placeholders(placeholders, "#{key}[#{idx}]", v)
+        build_placeholders(placeholders, "#{key}[#{idx-size}]", v) # support [-1]
+      end
+    elsif value.kind_of?(Hash) # record, etc
+      value.each do |k, v|
+        build_placeholders(placeholders, %Q[#{key}["#{k}"]], v) # record["foo"]
+      end
+    else
+      placeholders.store("${#{key}}", value)
+    end
+  end
+
+  def log_if_unknown_placeholder(placeholder, placeholders)
+    unless placeholders.include?(placeholder)
+      log.warn "pagerduty: unknown placeholder `#{placeholder}` found"
+    end
+  end
+end
+


### PR DESCRIPTION
We needed PagerDuty support in Fluentd and so naturally started with your plugin. However, we needed two additional things:
1. `incident_key` support to manage PagerDuty event de-duplication.
1. The ability to build `description`s and `incident_key`s from the source record (i.e. the source record was not already in the form PagerDuty expects).

While we might have been able to add the `description` handling we needed using an additional Fluentd plugin, there was no way to add `incident_key` handling without modifying your plugin (it requires a different constructor within the PagerDuty gem).

We are now using the modifications contained in the pull request and have vendored our modified version of the plugin for our production environment. In case these additions might be helpful to others, we packaged them up (including documentation) as this pull request.